### PR TITLE
feat/question crud and enhancements

### DIFF
--- a/frontend/src/@types/question.ts
+++ b/frontend/src/@types/question.ts
@@ -5,3 +5,11 @@ export interface Question {
   category: string[];
   complexity: string;
 }
+
+interface CreateQuestionFormData {
+  title: string;
+  description: string;
+  complexity: string;
+  categories: string[];
+  categoryInput: string;
+}

--- a/frontend/src/api/questionApi.tsx
+++ b/frontend/src/api/questionApi.tsx
@@ -84,3 +84,32 @@ export const deleteQuestionById = async (id: string, token: string) => {
     throw error;
   }
 };
+
+export const updateQuestion = async (
+  id: string,
+  data: CreateQuestionFormData,
+  token: string
+) => {
+  const payload = {
+    title: data.title,
+    description: data.description,
+    complexity: data.complexity,
+    category: data.categories,
+  };
+  try {
+    const response = await axios.put(
+      `${API_URL}/api/questions/${id}`,
+      payload,
+      {
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+      }
+    );
+    return response.data;
+  } catch (error) {
+    console.error("Error fetching question:", error);
+    throw error;
+  }
+};

--- a/frontend/src/api/questionApi.tsx
+++ b/frontend/src/api/questionApi.tsx
@@ -6,7 +6,7 @@ export const getAllQuestions = async ({
   page,
   limit,
   sort,
-  order
+  order,
 }: {
   page: number;
   limit: number;
@@ -14,11 +14,23 @@ export const getAllQuestions = async ({
   order: string;
 }) => {
   try {
-    const response = await axios.get(`${API_URL}/api/questions?page=${page}&limit=${limit}&sort=${sort}&order=${order}`);
+    const response = await axios.get(
+      `${API_URL}/api/questions?page=${page}&limit=${limit}&sort=${sort}&order=${order}`
+    );
     console.log(response);
     return response.data;
   } catch (error) {
     console.error("Error fetching questions:", error);
+    throw error;
+  }
+};
+
+export const fetchQuestionById = async (id: string) => {
+  try {
+    const response = await axios.get(`${API_URL}/api/questions/${id}`);
+    return response.data;
+  } catch (error) {
+    console.error("Error fetching question:", error);
     throw error;
   }
 };

--- a/frontend/src/api/questionApi.tsx
+++ b/frontend/src/api/questionApi.tsx
@@ -1,4 +1,5 @@
 import axios from "axios";
+import { CreateQuestionFormData } from "../@types/question";
 
 const API_URL = import.meta.env.VITE_QUESTION_API_URL;
 
@@ -39,6 +40,30 @@ export const getAllQuestions = async (
 export const fetchQuestionById = async (id: string) => {
   try {
     const response = await axios.get(`${API_URL}/api/questions/${id}`);
+    return response.data;
+  } catch (error) {
+    console.error("Error fetching question:", error);
+    throw error;
+  }
+};
+
+export const createQuestion = async (
+  data: CreateQuestionFormData,
+  token: string
+) => {
+  const payload = {
+    title: data.title,
+    description: data.description,
+    complexity: data.complexity,
+    category: data.categories,
+  };
+  try {
+    const response = await axios.post(`${API_URL}/api/questions`, payload, {
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+    });
     return response.data;
   } catch (error) {
     console.error("Error fetching question:", error);

--- a/frontend/src/api/questionApi.tsx
+++ b/frontend/src/api/questionApi.tsx
@@ -70,3 +70,17 @@ export const createQuestion = async (
     throw error;
   }
 };
+
+export const deleteQuestionById = async (id: string, token: string) => {
+  try {
+    await axios.delete(`${API_URL}/api/questions/${id}`, {
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+    });
+  } catch (error) {
+    console.error("Error fetching question:", error);
+    throw error;
+  }
+};

--- a/frontend/src/api/questionApi.tsx
+++ b/frontend/src/api/questionApi.tsx
@@ -17,7 +17,6 @@ export const getAllQuestions = async ({
     const response = await axios.get(
       `${API_URL}/api/questions?page=${page}&limit=${limit}&sort=${sort}&order=${order}`
     );
-    console.log(response);
     return response.data;
   } catch (error) {
     console.error("Error fetching questions:", error);

--- a/frontend/src/components/DeleteConfirmationModal.tsx
+++ b/frontend/src/components/DeleteConfirmationModal.tsx
@@ -1,0 +1,57 @@
+import React from "react";
+import { Modal, Box, Typography, Button, Stack } from "@mui/material";
+
+interface DeleteConfirmationModalProps {
+  open: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+}
+
+const DeleteConfirmationModal: React.FC<DeleteConfirmationModalProps> = ({
+  open,
+  onClose,
+  onConfirm,
+}) => {
+  return (
+    <Modal open={open} onClose={onClose} aria-labelledby="modal-title">
+      <Box
+        sx={{
+          position: "absolute",
+          top: "50%",
+          left: "50%",
+          transform: "translate(-50%, -50%)",
+          width: 400,
+          bgcolor: "background.paper",
+          borderRadius: 2,
+          boxShadow: 24,
+          p: 4,
+        }}
+      >
+        <Typography id="modal-title" variant="h6" gutterBottom>
+          Confirm Deletion
+        </Typography>
+        <Typography variant="body1" gutterBottom>
+          Are you sure you want to delete this question? This action cannot be
+          undone.
+        </Typography>
+        <Stack direction="row" spacing={2} justifyContent="flex-end" mt={3}>
+          <Button variant="outlined" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button
+            variant="contained"
+            color="error"
+            onClick={() => {
+              onConfirm();
+              onClose();
+            }}
+          >
+            Delete
+          </Button>
+        </Stack>
+      </Box>
+    </Modal>
+  );
+};
+
+export default DeleteConfirmationModal;

--- a/frontend/src/components/Highlight.tsx
+++ b/frontend/src/components/Highlight.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React from "react";
 
 interface HighlightProps {
   text: string;
@@ -8,17 +8,13 @@ interface HighlightProps {
 const Highlight: React.FC<HighlightProps> = ({ text, query }) => {
   if (!query) return <>{text}</>;
 
-  const regex = new RegExp(`(${query})`, 'gi');
+  const regex = new RegExp(`(${query})`, "gi");
   const parts = text.split(regex);
 
   return (
     <>
       {parts.map((part, index) =>
-        regex.test(part) ? (
-          <b key={index}>{part}</b>
-        ) : (
-          part
-        )
+        regex.test(part) ? <b key={index}>{part}</b> : part
       )}
     </>
   );

--- a/frontend/src/hooks/useDebounce.tsx
+++ b/frontend/src/hooks/useDebounce.tsx
@@ -1,21 +1,18 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState } from "react";
 
 export function useDebounce<T>(value: T, delay: number): T {
   const [debouncedValue, setDebouncedValue] = useState<T>(value);
 
-  useEffect(
-    () => {
-      const handler = setTimeout(() => {
-        setDebouncedValue(value);
-      }, delay);
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
 
-      // Cleanup function to cancel the timeout if value changes or component unmounts
-      return () => {
-        clearTimeout(handler);
-      };
-    },
-    [value, delay] 
-  );
+    // Cleanup function to cancel the timeout if value changes or component unmounts
+    return () => {
+      clearTimeout(handler);
+    };
+  }, [value, delay]);
 
   return debouncedValue;
 }

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -118,16 +118,16 @@ const Dashboard = () => {
   }, [sortBy]);
 
   useEffect(() => {
-    const filtered = questionAttempts.filter((attempt) =>
-      attempt.question.toLowerCase().includes(searchQuery.toLowerCase()) ||
-      attempt.topic.toLowerCase().includes(searchQuery.toLowerCase()) ||
-      attempt.difficulty.toLowerCase().includes(searchQuery.toLowerCase()) ||
-      attempt.peer.toLowerCase().includes(searchQuery.toLowerCase()) // Add checks for peer and difficulty as well
+    const filtered = questionAttempts.filter(
+      (attempt) =>
+        attempt.question.toLowerCase().includes(searchQuery.toLowerCase()) ||
+        attempt.topic.toLowerCase().includes(searchQuery.toLowerCase()) ||
+        attempt.difficulty.toLowerCase().includes(searchQuery.toLowerCase()) ||
+        attempt.peer.toLowerCase().includes(searchQuery.toLowerCase()) // Add checks for peer and difficulty as well
     );
     setFilteredQuestions(filtered);
     setCurrentPage(1);
   }, [searchQuery]);
-  
 
   const handlePageChange = (pageNumber: number) => {
     setCurrentPage(pageNumber);
@@ -135,19 +135,19 @@ const Dashboard = () => {
 
   const highlightText = (text: string, searchQuery: string) => {
     if (!searchQuery) return text;
-  
+
     // Escape special regex characters in the search query
     const escapeRegExp = (string: string) => {
-      return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      return string.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
     };
-  
+
     // Create a regular expression for the search term
     const escapedSearchTerm = escapeRegExp(searchQuery);
-    const regex = new RegExp(`(${escapedSearchTerm})`, 'gi');
-  
+    const regex = new RegExp(`(${escapedSearchTerm})`, "gi");
+
     // Split the text by the search term
     const parts = text.split(regex);
-  
+
     return (
       <>
         {parts.map((part, index) =>
@@ -265,10 +265,18 @@ const Dashboard = () => {
                 <TableBody>
                   {currentEntries.map((attempt, index) => (
                     <TableRow key={index}>
-                      <TableCell>{highlightText(attempt.question, searchQuery)}</TableCell>
-                      <TableCell>{highlightText(attempt.topic, searchQuery)}</TableCell>
-                      <TableCell>{highlightText(attempt.peer,searchQuery)}</TableCell>
-                      <TableCell>{highlightText(attempt.difficulty,searchQuery)}</TableCell>
+                      <TableCell>
+                        {highlightText(attempt.question, searchQuery)}
+                      </TableCell>
+                      <TableCell>
+                        {highlightText(attempt.topic, searchQuery)}
+                      </TableCell>
+                      <TableCell>
+                        {highlightText(attempt.peer, searchQuery)}
+                      </TableCell>
+                      <TableCell>
+                        {highlightText(attempt.difficulty, searchQuery)}
+                      </TableCell>
                     </TableRow>
                   ))}
                 </TableBody>

--- a/frontend/src/pages/EditQuestion.tsx
+++ b/frontend/src/pages/EditQuestion.tsx
@@ -1,0 +1,224 @@
+import {
+  Box,
+  Button,
+  Container,
+  Stack,
+  TextField,
+  Typography,
+  Chip,
+  MenuItem,
+} from "@mui/material";
+import Header from "../components/Header";
+import { useState, useEffect } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { updateQuestion, fetchQuestionById } from "../api/questionApi";
+import { toast } from "react-toastify";
+import { useAuth } from "../hooks/useAuth";
+import { CreateQuestionFormData } from "../@types/question";
+
+const EditQuestion = () => {
+  const { id } = useParams<{ id: string }>();
+  const { token } = useAuth();
+  const [formData, setFormData] = useState<CreateQuestionFormData>({
+    title: "",
+    description: "",
+    complexity: "Easy",
+    categories: [],
+    categoryInput: "",
+  });
+  const [loading, setLoading] = useState(true);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (id) {
+      fetchQuestionById(id)
+        .then((data) => {
+          setFormData({
+            title: data.title,
+            description: data.description,
+            complexity: data.complexity,
+            categories: data.category,
+            categoryInput: "",
+          });
+          setLoading(false);
+        })
+        .catch((error) => {
+          console.error("Failed to fetch question:", error);
+          toast.error("Failed to load question data.");
+          navigate(`/questions/${id}`);
+        });
+    }
+  }, [id, navigate]);
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setFormData((prevFormData) => ({
+      ...prevFormData,
+      [name]: value,
+    }));
+  };
+
+  const handleCategoryInputChange = (
+    e: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    setFormData((prevFormData) => ({
+      ...prevFormData,
+      categoryInput: e.target.value,
+    }));
+  };
+
+  const addCategory = (): void => {
+    const newCategory = formData.categoryInput.trim();
+    if (newCategory !== "" && !formData.categories.includes(newCategory)) {
+      setFormData((prevFormData: CreateQuestionFormData) => ({
+        ...prevFormData,
+        categories: [...prevFormData.categories, newCategory],
+        categoryInput: "",
+      }));
+    }
+  };
+
+  const removeCategory = (categoryToRemove: string) => {
+    setFormData((prevFormData) => ({
+      ...prevFormData,
+      categories: prevFormData.categories.filter(
+        (category) => category !== categoryToRemove
+      ),
+    }));
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      addCategory();
+    }
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      await updateQuestion(id!, formData, token);
+      toast.success("Question updated successfully");
+      navigate(`/questions/${id}`);
+    } catch (error) {
+      console.error("Failed to update question:", error);
+      toast.error("Failed to update question. Please try again.");
+    }
+  };
+
+  if (loading) {
+    return (
+      <Container maxWidth="lg" sx={{ mt: 3 }}>
+        <Typography variant="h6">Loading...</Typography>
+      </Container>
+    );
+  }
+
+  return (
+    <>
+      <Header />
+      <Container maxWidth="lg" sx={{ mt: 3 }}>
+        <Button variant="outlined" onClick={() => navigate(-1)} sx={{ mb: 2 }}>
+          Back To Question Repository
+        </Button>
+        <Box
+          p={3}
+          border={1}
+          borderColor="grey.300"
+          borderRadius={2}
+          boxShadow={1}
+          bgcolor="background.paper"
+        >
+          <Typography variant="h5" gutterBottom sx={{ mb: 2 }}>
+            Edit Question
+          </Typography>
+          <form onSubmit={handleSubmit}>
+            <Stack spacing={3}>
+              <TextField
+                label="Title"
+                variant="outlined"
+                name="title"
+                value={formData.title}
+                onChange={handleInputChange}
+                fullWidth
+                required
+              />
+              <TextField
+                label="Description"
+                variant="outlined"
+                name="description"
+                value={formData.description}
+                onChange={handleInputChange}
+                multiline
+                rows={4}
+                fullWidth
+                required
+              />
+              <TextField
+                select
+                label="Complexity"
+                variant="outlined"
+                name="complexity"
+                value={formData.complexity}
+                onChange={handleInputChange}
+                fullWidth
+                required
+              >
+                <MenuItem value="Easy">Easy</MenuItem>
+                <MenuItem value="Medium">Medium</MenuItem>
+                <MenuItem value="Hard">Hard</MenuItem>
+              </TextField>
+
+              <Box>
+                <Stack direction="row" spacing={2}>
+                  <TextField
+                    label="Category"
+                    variant="outlined"
+                    name="categoryInput"
+                    value={formData.categoryInput}
+                    onChange={handleCategoryInputChange}
+                    onKeyDown={handleKeyDown}
+                    fullWidth
+                  />
+                  <Button
+                    variant="contained"
+                    color="primary"
+                    onClick={addCategory}
+                    disabled={!formData.categoryInput.trim()}
+                  >
+                    Add
+                  </Button>
+                </Stack>
+                <Stack
+                  direction="row"
+                  spacing={1}
+                  sx={{ mt: 2, flexWrap: "wrap" }}
+                >
+                  {formData.categories.map((category, index) => (
+                    <Chip
+                      key={index}
+                      label={category}
+                      onDelete={() => removeCategory(category)}
+                      sx={{ mb: 1 }}
+                    />
+                  ))}
+                </Stack>
+              </Box>
+
+              <Button
+                variant="contained"
+                color="primary"
+                type="submit"
+                fullWidth
+              >
+                Update Question
+              </Button>
+            </Stack>
+          </form>
+        </Box>
+      </Container>
+    </>
+  );
+};
+
+export default EditQuestion;

--- a/frontend/src/pages/EditQuestion.tsx
+++ b/frontend/src/pages/EditQuestion.tsx
@@ -118,7 +118,11 @@ const EditQuestion = () => {
     <>
       <Header />
       <Container maxWidth="lg" sx={{ mt: 3 }}>
-        <Button variant="outlined" onClick={() => navigate(-1)} sx={{ mb: 2 }}>
+        <Button
+          variant="outlined"
+          onClick={() => navigate(`/questions`)}
+          sx={{ mb: 2 }}
+        >
           Back To Question Repository
         </Button>
         <Box

--- a/frontend/src/pages/ManageQuestions.tsx
+++ b/frontend/src/pages/ManageQuestions.tsx
@@ -88,7 +88,11 @@ const ManageQuestions = () => {
     <>
       <Header />
       <Container maxWidth="lg" sx={{ mt: 3 }}>
-        <Button variant="outlined" onClick={() => navigate(-1)} sx={{ mb: 2 }}>
+        <Button
+          variant="outlined"
+          onClick={() => navigate("/questions")}
+          sx={{ mb: 2 }}
+        >
           Back To Question Repository
         </Button>
         <Box

--- a/frontend/src/pages/ManageQuestions.tsx
+++ b/frontend/src/pages/ManageQuestions.tsx
@@ -21,7 +21,7 @@ const ManageQuestions = () => {
   const [formData, setFormData] = useState<CreateQuestionFormData>({
     title: "",
     description: "",
-    complexity: "easy",
+    complexity: "Easy",
     categories: [],
     categoryInput: "",
   });
@@ -100,7 +100,7 @@ const ManageQuestions = () => {
           bgcolor="background.paper"
         >
           <Typography variant="h5" gutterBottom sx={{ mb: 2 }}>
-            Create a New Question
+            Create a new question
           </Typography>
           <form onSubmit={handleSubmit}>
             <Stack spacing={3}>
@@ -134,9 +134,9 @@ const ManageQuestions = () => {
                 fullWidth
                 required
               >
-                <MenuItem value="easy">Easy</MenuItem>
-                <MenuItem value="medium">Medium</MenuItem>
-                <MenuItem value="hard">Hard</MenuItem>
+                <MenuItem value="Easy">Easy</MenuItem>
+                <MenuItem value="Medium">Medium</MenuItem>
+                <MenuItem value="Hard">Hard</MenuItem>
               </TextField>
 
               <Box>

--- a/frontend/src/pages/ManageQuestions.tsx
+++ b/frontend/src/pages/ManageQuestions.tsx
@@ -1,0 +1,27 @@
+import { Box, Button, Container } from "@mui/material";
+import Header from "../components/Header";
+import { useNavigate } from "react-router-dom";
+
+const ManageQuestions = () => {
+  const navigate = useNavigate();
+  return (
+    <>
+      <Header></Header>
+      <Container maxWidth="lg" sx={{ mt: 3 }}>
+        <Button variant="outlined" onClick={() => navigate(-1)} sx={{ mb: 2 }}>
+          Back To Question Repository
+        </Button>
+        <Box
+          p={3}
+          border={1}
+          borderColor="grey.300"
+          borderRadius={2}
+          boxShadow={1}
+          bgcolor="background.paper"
+        ></Box>
+      </Container>
+    </>
+  );
+};
+
+export default ManageQuestions;

--- a/frontend/src/pages/ManageQuestions.tsx
+++ b/frontend/src/pages/ManageQuestions.tsx
@@ -1,12 +1,92 @@
-import { Box, Button, Container } from "@mui/material";
+import {
+  Box,
+  Button,
+  Container,
+  Stack,
+  TextField,
+  Typography,
+  Chip,
+  MenuItem,
+} from "@mui/material";
 import Header from "../components/Header";
+import { useState } from "react";
 import { useNavigate } from "react-router-dom";
+import { createQuestion } from "../api/questionApi";
+import { toast } from "react-toastify";
+import { useAuth } from "../hooks/useAuth";
+import { CreateQuestionFormData } from "../@types/question";
 
 const ManageQuestions = () => {
+  const { token } = useAuth();
+  const [formData, setFormData] = useState<CreateQuestionFormData>({
+    title: "",
+    description: "",
+    complexity: "easy",
+    categories: [],
+    categoryInput: "",
+  });
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setFormData((prevFormData) => ({
+      ...prevFormData,
+      [name]: value,
+    }));
+  };
+
+  const handleCategoryInputChange = (
+    e: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    setFormData((prevFormData) => ({
+      ...prevFormData,
+      categoryInput: e.target.value,
+    }));
+  };
+
+  const addCategory = (): void => {
+    const newCategory = formData.categoryInput.trim();
+    if (newCategory !== "" && !formData.categories.includes(newCategory)) {
+      setFormData((prevFormData: CreateQuestionFormData) => ({
+        ...prevFormData,
+        categories: [...prevFormData.categories, newCategory],
+        categoryInput: "",
+      }));
+    }
+  };
+
+  const removeCategory = (categoryToRemove: string) => {
+    setFormData((prevFormData) => ({
+      ...prevFormData,
+      categories: prevFormData.categories.filter(
+        (category) => category !== categoryToRemove
+      ),
+    }));
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      addCategory();
+    }
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      await createQuestion(formData, token);
+      toast.success("Question created successfully");
+      navigate("/questions");
+    } catch (error) {
+      console.error("Failed to create question:", error);
+      toast.error("Failed to create question. Please try again.");
+    }
+  };
+
   const navigate = useNavigate();
+
   return (
     <>
-      <Header></Header>
+      <Header />
       <Container maxWidth="lg" sx={{ mt: 3 }}>
         <Button variant="outlined" onClick={() => navigate(-1)} sx={{ mb: 2 }}>
           Back To Question Repository
@@ -18,7 +98,94 @@ const ManageQuestions = () => {
           borderRadius={2}
           boxShadow={1}
           bgcolor="background.paper"
-        ></Box>
+        >
+          <Typography variant="h5" gutterBottom sx={{ mb: 2 }}>
+            Create a New Question
+          </Typography>
+          <form onSubmit={handleSubmit}>
+            <Stack spacing={3}>
+              <TextField
+                label="Title"
+                variant="outlined"
+                name="title"
+                value={formData.title}
+                onChange={handleInputChange}
+                fullWidth
+                required
+              />
+              <TextField
+                label="Description"
+                variant="outlined"
+                name="description"
+                value={formData.description}
+                onChange={handleInputChange}
+                multiline
+                rows={4}
+                fullWidth
+                required
+              />
+              <TextField
+                select
+                label="Complexity"
+                variant="outlined"
+                name="complexity"
+                value={formData.complexity}
+                onChange={handleInputChange}
+                fullWidth
+                required
+              >
+                <MenuItem value="easy">Easy</MenuItem>
+                <MenuItem value="medium">Medium</MenuItem>
+                <MenuItem value="hard">Hard</MenuItem>
+              </TextField>
+
+              <Box>
+                <Stack direction="row" spacing={2}>
+                  <TextField
+                    label="Category"
+                    variant="outlined"
+                    name="categoryInput"
+                    value={formData.categoryInput}
+                    onChange={handleCategoryInputChange}
+                    onKeyDown={handleKeyDown}
+                    fullWidth
+                  />
+                  <Button
+                    variant="contained"
+                    color="primary"
+                    onClick={addCategory}
+                    disabled={!formData.categoryInput.trim()}
+                  >
+                    Add
+                  </Button>
+                </Stack>
+                <Stack
+                  direction="row"
+                  spacing={1}
+                  sx={{ mt: 2, flexWrap: "wrap" }}
+                >
+                  {formData.categories.map((category, index) => (
+                    <Chip
+                      key={index}
+                      label={category}
+                      onDelete={() => removeCategory(category)}
+                      sx={{ mb: 1 }}
+                    />
+                  ))}
+                </Stack>
+              </Box>
+
+              <Button
+                variant="contained"
+                color="primary"
+                type="submit"
+                fullWidth
+              >
+                Create Question
+              </Button>
+            </Stack>
+          </form>
+        </Box>
       </Container>
     </>
   );

--- a/frontend/src/pages/QuestionDetails.tsx
+++ b/frontend/src/pages/QuestionDetails.tsx
@@ -1,6 +1,6 @@
 import { useParams, useNavigate } from "react-router-dom";
 import Header from "../components/Header";
-import { fetchQuestionById } from "../api/questionApi";
+import { deleteQuestionById, fetchQuestionById } from "../api/questionApi";
 import { useEffect, useState } from "react";
 import { Question } from "../@types/question";
 import {
@@ -12,12 +12,17 @@ import {
   Divider,
   Button,
 } from "@mui/material";
+import { toast } from "react-toastify";
+import { useAuth } from "../hooks/useAuth";
+import DeleteConfirmationModal from "../components/DeleteConfirmationModal";
 
 const QuestionDetails = () => {
   const { id } = useParams<{ id: string | undefined }>();
   const navigate = useNavigate();
   const [question, setQuestion] = useState<Question>();
   const [error, setError] = useState<string | null>(null);
+  const { token } = useAuth();
+  const [isDeleteModalOpen, setDeleteModalOpen] = useState(false);
 
   useEffect(() => {
     if (id) {
@@ -52,13 +57,61 @@ const QuestionDetails = () => {
     }
   };
 
+  const handleDelete = async () => {
+    if (id) {
+      try {
+        await deleteQuestionById(id, token);
+        toast.success("Question deleted successfully");
+        navigate("/questions");
+      } catch (error) {
+        console.error("Failed to delete question:", error);
+        toast.error("Failed to delete question. Please try again.");
+      }
+    }
+  };
+
   return (
     <>
       <Header></Header>
       <Container maxWidth="lg" sx={{ mt: 3 }}>
-        <Button variant="outlined" onClick={() => navigate(-1)} sx={{ mb: 2 }}>
-          Back To Question Repository
-        </Button>
+        <Box
+          display="flex"
+          alignItems="center"
+          justifyContent="space-between"
+          mt={2}
+        >
+          <Button
+            variant="outlined"
+            onClick={() => navigate(-1)}
+            sx={{ mb: 2 }}
+          >
+            Back To Question Repository
+          </Button>
+          <Box display="flex" alignItems="center">
+            <Button
+              variant="contained"
+              sx={{
+                mb: 2,
+                mr: 2,
+                color: "white",
+                backgroundColor: "green",
+              }}
+            >
+              Edit
+            </Button>
+            <Button
+              variant="contained"
+              sx={{
+                mb: 2,
+                color: "white",
+                backgroundColor: "red",
+              }}
+              onClick={() => setDeleteModalOpen(true)}
+            >
+              Delete
+            </Button>
+          </Box>
+        </Box>
         <Box
           p={3}
           border={1}
@@ -107,6 +160,11 @@ const QuestionDetails = () => {
           )}
         </Box>
       </Container>
+      <DeleteConfirmationModal
+        open={isDeleteModalOpen}
+        onClose={() => setDeleteModalOpen(false)}
+        onConfirm={handleDelete}
+      />
     </>
   );
 };

--- a/frontend/src/pages/QuestionDetails.tsx
+++ b/frontend/src/pages/QuestionDetails.tsx
@@ -1,0 +1,114 @@
+import { useParams, useNavigate } from "react-router-dom";
+import Header from "../components/Header";
+import { fetchQuestionById } from "../api/questionApi";
+import { useEffect, useState } from "react";
+import { Question } from "../@types/question";
+import {
+  Box,
+  Container,
+  Typography,
+  Chip,
+  Stack,
+  Divider,
+  Button,
+} from "@mui/material";
+
+const QuestionDetails = () => {
+  const { id } = useParams<{ id: string | undefined }>();
+  const navigate = useNavigate();
+  const [question, setQuestion] = useState<Question>();
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (id) {
+      fetchQuestionById(id)
+        .then((data) => {
+          if (data) {
+            setQuestion(data);
+            setError(null);
+          } else {
+            setError("Question not found");
+          }
+        })
+        .catch((error) => {
+          console.error("Error fetching question details:", error);
+          setError("Error fetching question details");
+        });
+    } else {
+      setError("Invalid question ID");
+    }
+  }, [id]);
+
+  const getChipColor = (complexity: string) => {
+    switch (complexity) {
+      case "Easy":
+        return "success";
+      case "Medium":
+        return "warning";
+      case "Hard":
+        return "error";
+      default:
+        return "default";
+    }
+  };
+
+  return (
+    <>
+      <Header></Header>
+      <Container maxWidth="lg" sx={{ mt: 3 }}>
+        <Button variant="outlined" onClick={() => navigate(-1)} sx={{ mb: 2 }}>
+          Back To Question Repository
+        </Button>
+        <Box
+          p={3}
+          border={1}
+          borderColor="grey.300"
+          borderRadius={2}
+          boxShadow={1}
+          bgcolor="background.paper"
+        >
+          {error ? (
+            <Typography variant="h6" color="error">
+              Error: {error}
+            </Typography>
+          ) : (
+            question && (
+              <>
+                <Stack
+                  direction="row"
+                  justifyContent="space-between"
+                  alignItems="center"
+                  mb={2}
+                >
+                  <Typography variant="h5">{question.title}</Typography>
+                  <Chip
+                    label={question.complexity}
+                    color={getChipColor(question.complexity)}
+                    variant="outlined"
+                  />
+                </Stack>
+                <Divider sx={{ mb: 2 }} />
+                <Typography variant="body1" paragraph>
+                  {question.description.split("\n").map((line, index) => (
+                    <span key={index}>
+                      {line}
+                      <br />
+                    </span>
+                  ))}
+                </Typography>
+                <Divider sx={{ mt: 2, mb: 2 }} />
+                <Stack direction="row" spacing={1}>
+                  {question.category?.map((topic) => (
+                    <Chip key={topic} label={topic} variant="outlined" />
+                  ))}
+                </Stack>
+              </>
+            )
+          )}
+        </Box>
+      </Container>
+    </>
+  );
+};
+
+export default QuestionDetails;

--- a/frontend/src/pages/QuestionDetails.tsx
+++ b/frontend/src/pages/QuestionDetails.tsx
@@ -21,7 +21,7 @@ const QuestionDetails = () => {
   const navigate = useNavigate();
   const [question, setQuestion] = useState<Question>();
   const [error, setError] = useState<string | null>(null);
-  const { token } = useAuth();
+  const { token, user } = useAuth();
   const [isDeleteModalOpen, setDeleteModalOpen] = useState(false);
 
   useEffect(() => {
@@ -33,16 +33,19 @@ const QuestionDetails = () => {
             setError(null);
           } else {
             setError("Question not found");
+            navigate("/404");
           }
         })
         .catch((error) => {
           console.error("Error fetching question details:", error);
           setError("Error fetching question details");
+          navigate("/404");
         });
     } else {
       setError("Invalid question ID");
+      navigate("/404");
     }
-  }, [id]);
+  }, [id, navigate]);
 
   const getChipColor = (complexity: string) => {
     switch (complexity) {
@@ -87,30 +90,33 @@ const QuestionDetails = () => {
           >
             Back To Question Repository
           </Button>
-          <Box display="flex" alignItems="center">
-            <Button
-              variant="contained"
-              sx={{
-                mb: 2,
-                mr: 2,
-                color: "white",
-                backgroundColor: "green",
-              }}
-            >
-              Edit
-            </Button>
-            <Button
-              variant="contained"
-              sx={{
-                mb: 2,
-                color: "white",
-                backgroundColor: "red",
-              }}
-              onClick={() => setDeleteModalOpen(true)}
-            >
-              Delete
-            </Button>
-          </Box>
+          {user?.isAdmin && (
+            <Box display="flex" alignItems="center">
+              <Button
+                variant="contained"
+                sx={{
+                  mb: 2,
+                  mr: 2,
+                  color: "white",
+                  backgroundColor: "green",
+                }}
+                onClick={() => navigate(`/questions/${id}/edit`)}
+              >
+                Edit
+              </Button>
+              <Button
+                variant="contained"
+                sx={{
+                  mb: 2,
+                  color: "white",
+                  backgroundColor: "red",
+                }}
+                onClick={() => setDeleteModalOpen(true)}
+              >
+                Delete
+              </Button>
+            </Box>
+          )}
         </Box>
         <Box
           p={3}
@@ -133,7 +139,14 @@ const QuestionDetails = () => {
                   alignItems="center"
                   mb={2}
                 >
-                  <Typography variant="h5">{question.title}</Typography>
+                  <Box
+                    sx={{
+                      whiteSpace: "pre-wrap",
+                      wordBreak: "break-word",
+                    }}
+                  >
+                    <Typography variant="h5">{question.title}</Typography>
+                  </Box>
                   <Chip
                     label={question.complexity}
                     color={getChipColor(question.complexity)}
@@ -141,18 +154,35 @@ const QuestionDetails = () => {
                   />
                 </Stack>
                 <Divider sx={{ mb: 2 }} />
-                <Typography variant="body1" paragraph>
-                  {question.description.split("\n").map((line, index) => (
-                    <span key={index}>
-                      {line}
-                      <br />
-                    </span>
-                  ))}
-                </Typography>
+                <Box
+                  sx={{
+                    whiteSpace: "pre-wrap",
+                    wordBreak: "break-word",
+                  }}
+                >
+                  <Typography variant="body1" paragraph>
+                    {question.description.split("\n").map((line, index) => (
+                      <span key={index}>
+                        {line}
+                        <br />
+                      </span>
+                    ))}
+                  </Typography>
+                </Box>
                 <Divider sx={{ mt: 2, mb: 2 }} />
-                <Stack direction="row" spacing={1}>
+                <Stack direction="row" spacing={1} sx={{ flexWrap: "wrap" }}>
                   {question.category?.map((topic) => (
-                    <Chip key={topic} label={topic} variant="outlined" />
+                    <Chip
+                      key={topic}
+                      label={topic}
+                      variant="outlined"
+                      sx={{
+                        maxWidth: 200,
+                        whiteSpace: "nowrap",
+                        overflow: "hidden",
+                        textOverflow: "ellipsis",
+                      }}
+                    />
                   ))}
                 </Stack>
               </>

--- a/frontend/src/pages/QuestionDetails.tsx
+++ b/frontend/src/pages/QuestionDetails.tsx
@@ -85,7 +85,7 @@ const QuestionDetails = () => {
         >
           <Button
             variant="outlined"
-            onClick={() => navigate(-1)}
+            onClick={() => navigate("/questions")}
             sx={{ mb: 2 }}
           >
             Back To Question Repository

--- a/frontend/src/pages/QuestionRepo.tsx
+++ b/frontend/src/pages/QuestionRepo.tsx
@@ -12,13 +12,16 @@ import {
   IconButton,
   MenuItem,
   TextField,
+  Button,
 } from "@mui/material";
 import Header from "../components/Header";
 import { getAllQuestions } from "../api/questionApi"; // Ensure your API supports pagination & sorting params
 import { Question } from "../@types/question";
 import { useNavigate } from "react-router-dom";
+import { useAuth } from "../hooks/useAuth";
 
 const QuestionRepo = () => {
+  const { user } = useAuth();
   const [questions, setQuestions] = useState<Question[]>([]);
   const [currentPage, setCurrentPage] = useState(1);
   const [totalPages, setTotalPages] = useState(1);
@@ -69,6 +72,10 @@ const QuestionRepo = () => {
     setSortOrder(event.target.value as string);
   };
 
+  const navigateToManageQuestions = () => {
+    navigate("/questions/manage");
+  };
+
   return (
     <>
       <Header />
@@ -83,40 +90,50 @@ const QuestionRepo = () => {
           <Typography variant="h6" gutterBottom>
             Question Repository
           </Typography>
-
           {/* Sorting Controls */}
           <Box
             display="flex"
-            justifyContent="space-between"
             alignItems="center"
-            mb={3}
+            justifyContent="space-between"
+            mt={2}
           >
-            <TextField
-              select
-              label="Sort By"
-              value={sortField}
-              onChange={handleSortChange}
-              size="small"
-              variant="outlined"
-              // sx={{ width: 150 }}
-            >
-              <MenuItem value="title">Title</MenuItem>
-              <MenuItem value="complexity">Complexity</MenuItem>
-              <MenuItem value="category">Category</MenuItem>
-            </TextField>
+            <Box display="flex" alignItems="center" mb={3}>
+              <TextField
+                select
+                label="Sort By"
+                value={sortField}
+                onChange={handleSortChange}
+                size="small"
+                variant="outlined"
+                sx={{ mr: 2 }}
+              >
+                <MenuItem value="title">Title</MenuItem>
+                <MenuItem value="complexity">Complexity</MenuItem>
+                <MenuItem value="category">Category</MenuItem>
+              </TextField>
 
-            <TextField
-              select
-              label="Order"
-              value={sortOrder}
-              onChange={handleOrderChange}
-              size="small"
-              variant="outlined"
-              // sx={{ width: 150 }}
-            >
-              <MenuItem value="asc">Ascending</MenuItem>
-              <MenuItem value="desc">Descending</MenuItem>
-            </TextField>
+              <TextField
+                select
+                label="Order"
+                value={sortOrder}
+                onChange={handleOrderChange}
+                size="small"
+                variant="outlined"
+                // sx={{ width: 150 }}
+              >
+                <MenuItem value="asc">Ascending</MenuItem>
+                <MenuItem value="desc">Descending</MenuItem>
+              </TextField>
+            </Box>
+            {user?.isAdmin && (
+              <Button
+                variant="outlined"
+                onClick={navigateToManageQuestions}
+                sx={{ mb: 2 }}
+              >
+                + Create Question
+              </Button>
+            )}
           </Box>
           <Paper elevation={3}>
             <Table>

--- a/frontend/src/pages/QuestionRepo.tsx
+++ b/frontend/src/pages/QuestionRepo.tsx
@@ -129,6 +129,10 @@ const QuestionRepo = () => {
     navigate("/questions/manage");
   };
 
+  const handleRowClick = (id: string) => {
+    navigate(`/questions/${id}`);
+  };
+
   return (
     <>
       <Header />
@@ -226,7 +230,12 @@ const QuestionRepo = () => {
                   </TableHead>
                   <TableBody>
                     {questions.map((question) => (
-                      <TableRow key={question._id}>
+                      <TableRow
+                        key={question._id}
+                        hover
+                        onClick={() => handleRowClick(question._id)}
+                        style={{ cursor: "pointer" }}
+                      >
                         <TableCell>
                           <Highlight
                             text={question.title}

--- a/frontend/src/pages/QuestionRepo.tsx
+++ b/frontend/src/pages/QuestionRepo.tsx
@@ -11,11 +11,12 @@ import {
   Typography,
   IconButton,
   MenuItem,
-  TextField
+  TextField,
 } from "@mui/material";
 import Header from "../components/Header";
 import { getAllQuestions } from "../api/questionApi"; // Ensure your API supports pagination & sorting params
 import { Question } from "../@types/question";
+import { useNavigate } from "react-router-dom";
 
 const QuestionRepo = () => {
   const [questions, setQuestions] = useState<Question[]>([]);
@@ -27,10 +28,21 @@ const QuestionRepo = () => {
   const [sortField, setSortField] = useState<string>("title"); // Default sort field
   const [sortOrder, setSortOrder] = useState<string>("asc"); // Default sort order
 
+  const navigate = useNavigate();
+
+  const handleRowClick = (id: string) => {
+    navigate(`/questions/${id}`);
+  };
+
   const fetchQuestions = async (page: number, sort: string, order: string) => {
     try {
       // Fetch questions with pagination and sorting
-      const data = await getAllQuestions({ page, limit: entriesPerPage, sort, order });
+      const data = await getAllQuestions({
+        page,
+        limit: entriesPerPage,
+        sort,
+        order,
+      });
       setQuestions(data.questions);
       setCurrentPage(data.currentPage);
       setTotalPages(data.totalPages);
@@ -73,7 +85,12 @@ const QuestionRepo = () => {
           </Typography>
 
           {/* Sorting Controls */}
-          <Box display="flex" justifyContent="space-between" alignItems="center" mb={3}>
+          <Box
+            display="flex"
+            justifyContent="space-between"
+            alignItems="center"
+            mb={3}
+          >
             <TextField
               select
               label="Sort By"
@@ -83,9 +100,9 @@ const QuestionRepo = () => {
               variant="outlined"
               // sx={{ width: 150 }}
             >
-                <MenuItem value="title">Title</MenuItem>
-                <MenuItem value="complexity">Complexity</MenuItem>
-                <MenuItem value="category">Category</MenuItem>
+              <MenuItem value="title">Title</MenuItem>
+              <MenuItem value="complexity">Complexity</MenuItem>
+              <MenuItem value="category">Category</MenuItem>
             </TextField>
 
             <TextField
@@ -112,7 +129,12 @@ const QuestionRepo = () => {
               </TableHead>
               <TableBody>
                 {questions.map((question) => (
-                  <TableRow key={question._id}>
+                  <TableRow
+                    key={question._id}
+                    hover
+                    onClick={() => handleRowClick(question._id)}
+                    style={{ cursor: "pointer" }}
+                  >
                     <TableCell>{question.title}</TableCell>
                     <TableCell></TableCell>
                     <TableCell>{question.complexity}</TableCell>

--- a/frontend/src/routes/AdminRoutes.tsx
+++ b/frontend/src/routes/AdminRoutes.tsx
@@ -1,0 +1,18 @@
+import { Navigate, Outlet } from "react-router-dom";
+import { useAuth } from "../hooks/useAuth";
+
+const AdminRoute = () => {
+  const { isAuthenticated, isLoading, user } = useAuth();
+
+  if (isLoading) {
+    return <div>Loading...</div>;
+  }
+
+  if (!isAuthenticated || !user?.isAdmin) {
+    return <Navigate to="/dashboard" replace />;
+  }
+
+  return <Outlet />;
+};
+
+export default AdminRoute;

--- a/frontend/src/routes/AdminRoutes.tsx
+++ b/frontend/src/routes/AdminRoutes.tsx
@@ -9,7 +9,7 @@ const AdminRoute = () => {
   }
 
   if (!isAuthenticated || !user?.isAdmin) {
-    return <Navigate to="/dashboard" replace />;
+    return <Navigate to="/404" replace />;
   }
 
   return <Outlet />;

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -9,6 +9,7 @@ import QuestionRepo from "../pages/QuestionRepo";
 import QuestionDetails from "../pages/QuestionDetails";
 import ManageQuestions from "../pages/ManageQuestions";
 import AdminRoute from "./AdminRoutes";
+import EditQuestion from "../pages/EditQuestion";
 
 const router = createBrowserRouter([
   {
@@ -58,6 +59,16 @@ const router = createBrowserRouter([
       {
         path: ":id",
         element: <QuestionDetails />,
+      },
+      {
+        path: ":id/edit",
+        element: <AdminRoute />,
+        children: [
+          {
+            path: "",
+            element: <EditQuestion />,
+          },
+        ],
       },
     ],
   },

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -7,6 +7,8 @@ import EditProfile from "../pages/EditProfile";
 import ChangePassword from "../pages/ChangePassword";
 import QuestionRepo from "../pages/QuestionRepo";
 import QuestionDetails from "../pages/QuestionDetails";
+import ManageQuestions from "../pages/ManageQuestions";
+import AdminRoute from "./AdminRoutes";
 
 const router = createBrowserRouter([
   {
@@ -42,6 +44,16 @@ const router = createBrowserRouter([
       {
         path: "",
         element: <QuestionRepo />,
+      },
+      {
+        path: "manage",
+        element: <AdminRoute />,
+        children: [
+          {
+            path: "",
+            element: <ManageQuestions />,
+          },
+        ],
       },
       {
         path: ":id",

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -6,6 +6,7 @@ import ProtectedRoute from "./ProtectedRoutes";
 import EditProfile from "../pages/EditProfile";
 import ChangePassword from "../pages/ChangePassword";
 import QuestionRepo from "../pages/QuestionRepo";
+import QuestionDetails from "../pages/QuestionDetails";
 
 const router = createBrowserRouter([
   {
@@ -41,6 +42,10 @@ const router = createBrowserRouter([
       {
         path: "",
         element: <QuestionRepo />,
+      },
+      {
+        path: ":id",
+        element: <QuestionDetails />,
       },
     ],
   },


### PR DESCRIPTION
## Changes
- Create question details page to display title, description etc. of specific question
<img width="959" alt="image" src="https://github.com/user-attachments/assets/51d8c17d-7419-49ed-8423-075e4e3f9882">

- Creation of adminRoutes: Only admin can access these routes, else navigate to /404

- CRUD of questions. Buttons will only render when you are an admin:

Create: Form to fill in and submit data
<img width="959" alt="image" src="https://github.com/user-attachments/assets/d3e64344-f3b2-48a6-bb0f-2d56cc1883e3">

Edit: Form with prefilled data of question
<img width="957" alt="image" src="https://github.com/user-attachments/assets/b20bc720-5841-4016-8bde-11e6ce75677d">

Delete: Confirmation Modal
<img width="958" alt="image" src="https://github.com/user-attachments/assets/47e3da60-581d-4d89-9e22-1c3e847eef69">

Note: Edit and Delete buttons are found in question details page for now.
Others: Standardise prettier formatting of code.
