### PR TITLE
Update matching criteria for matching service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,25 @@
 version: "3.9"
 
 services:
+  rabbitmq:
+    image: rabbitmq:management
+    ports:
+      - "5672:5672"
+      - "15672:15672"
+    networks:
+      - demo-network
+    healthcheck: 
+      test: ["CMD", "rabbitmq-diagnostics", "ping"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+  redis: 
+    image: redis:alpine
+    ports:
+      - "6379:6379"
+    networks:
+      - demo-network
+
   user-service:
     build: ./user-service
     ports:
@@ -40,6 +59,29 @@ services:
           #   - node_modules/
         - action: rebuild
           path: ./question-service/package.json
+  matching-service:
+    build: ./matching-service
+    ports:
+      - 3000:3000
+    depends_on:
+      rabbitmq:
+        condition: service_healthy
+      redis: 
+        condition: service_started
+    environment: 
+      RABBITMQ_URL: amqp://rabbitmq:5672
+      REDIS_URL: redis://redis:6379
+    networks:
+      - demo-network
+    develop:
+      watch:
+        - action: sync
+          path: ./matching-service
+          target: /app
+          # ignore:
+          #   - node_modules/
+        - action: rebuild
+          path: ./matching-service/package.json
 
   frontend:
     build: ./frontend

--- a/matching-service/Dockerfile
+++ b/matching-service/Dockerfile
@@ -1,0 +1,20 @@
+FROM node:20
+
+# Create a non-privileged user
+RUN useradd -ms /bin/sh -u 1001 app
+
+# Switch to the non-privileged user
+USER app
+
+WORKDIR /app
+
+COPY --chown=app:app package.json package-lock.json ./
+
+RUN npm install
+
+# Copy the rest of the application code
+COPY --chown=app:app . /app
+
+EXPOSE 3000
+
+CMD ["npm", "run", "dev"]

--- a/matching-service/src/queue/rabbitmq.ts
+++ b/matching-service/src/queue/rabbitmq.ts
@@ -2,10 +2,12 @@ import amqp, { Connection, Channel } from 'amqplib';
 
 let connection: Connection | null = null;
 let channel: Channel | null = null;
+const RABBITMQ_URL = process.env.RABBITMQ_URL || "amqp://localhost";
 
 export async function connectRabbitMQ(): Promise<void> {
   if (connection) return; // Already connected
-  connection = await amqp.connect('amqp://localhost');
+  console.log('Connecting to RabbitMQ server:', RABBITMQ_URL);
+  connection = await amqp.connect(RABBITMQ_URL);
   channel = await connection.createChannel();
   await channel.assertQueue('match_requests');
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "cs3219-ay2425s1-project-g27",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
Current implementation only allows exact match based on topic AND difficulty and will timeout after 30s if no exact match is found. 

Since topic is placed at a higher priority compared to difficulty based on m4 requirements file, we will update the implementation to match based on same topic instead (when there is no exact match). Since there is more topics compared to the levels of difficulty, this implementation also ensures a higher probability of users getting matched to their exact match. 

Also updated the docker compose file to include matching service, redis and rabbitmq. 